### PR TITLE
Use FRBRnumber in FRBRWork. Fixes #8

### DIFF
--- a/cobalt/akn.py
+++ b/cobalt/akn.py
@@ -187,6 +187,7 @@ class StructuredDocument(AkomaNtosoDocument):
                             E.FRBRdate(date=today, name="Generation"),
                             E.FRBRauthor(href=""),
                             E.FRBRcountry(value=frbr_uri.country),
+                            E.FRBRnumber(value=frbr_uri.number),
                         ),
                         E.FRBRExpression(
                             E.FRBRuri(value=frbr_uri.expression_uri(work_component=False)),
@@ -347,6 +348,7 @@ class StructuredDocument(AkomaNtosoDocument):
             ident.FRBRWork.FRBRuri.set('value', uri.uri())
             ident.FRBRWork.FRBRthis.set('value', uri.work_uri())
             ident.FRBRWork.FRBRcountry.set('value', uri.country)
+            self.ensure_element('FRBRnumber', at=ident.FRBRWork, after=ident.FRBRWork.FRBRcountry).set('value', uri.number)
             if uri.subtype:
                 self.ensure_element('FRBRsubtype', at=ident.FRBRWork, after=ident.FRBRWork.FRBRcountry).set('value', uri.subtype)
             else:

--- a/tests/test_structured_document.py
+++ b/tests/test_structured_document.py
@@ -339,6 +339,7 @@ class ActTestCase(TestCase):
           <FRBRdate date="TODAY" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
+          <FRBRnumber value="1"/>
         </FRBRWork>
         <FRBRExpression>
           <FRBRuri value="/akn/za/act/1900/1/eng@TODAY"/>
@@ -387,6 +388,7 @@ class ActTestCase(TestCase):
           <FRBRdate date="TODAY" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
+          <FRBRnumber value="1"/>
         </FRBRWork>
         <FRBRExpression>
           <FRBRuri value="/akn/za/act/1900/1/eng@TODAY"/>
@@ -446,6 +448,7 @@ class ActTestCase(TestCase):
           <FRBRdate date="TODAY" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
+          <FRBRnumber value="1"/>
         </FRBRWork>
         <FRBRExpression>
           <FRBRuri value="/akn/za/act/1900/1/eng@TODAY"/>


### PR DESCRIPTION
The element is optional in the schema, so we can't assume it is there.
However, the standard says that it must exist for FRBR URIs with a
number.