### PR TITLE
FRBRdate is the uri's date in FRBRwork. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ Change Log
 - Start FRBR URI work component with ``!`` (eg. ``!main``)
 - FRBRcountry uses full country code from the FRBR URI
 - FRBRnumber uses number portion from FRBR URI
+- FRBRdate for FRBRWork contains the date portion of the FRBR URI
 - Include AKN 3.0 schema and support for validating against the schema
 
 3.1.1

--- a/cobalt/akn.py
+++ b/cobalt/akn.py
@@ -291,12 +291,12 @@ class StructuredDocument(AkomaNtosoDocument):
 
     @property
     def work_date(self):
-        """ Date from the FRBRWork element """
+        """ Date from the FRBRWork element. Normally, this date must match the date portion of the work's FRBR URI.
+        However, since that may be a partial date (such as just a year), this return value may be different to the
+        date string stored in the FRBRdate element. In particular, if the date is just a year, the month and day
+        both default to 1.
+        """
         return parse_date(self.meta.identification.FRBRWork.FRBRdate.get('date')).date()
-
-    @work_date.setter
-    def work_date(self, value):
-        self.meta.identification.FRBRWork.FRBRdate.set('date', datestring(value))
 
     @property
     def expression_date(self):

--- a/cobalt/akn.py
+++ b/cobalt/akn.py
@@ -183,7 +183,7 @@ class StructuredDocument(AkomaNtosoDocument):
                             E.FRBRthis(value=frbr_uri.work_uri()),
                             E.FRBRuri(value=frbr_uri.work_uri(work_component=False)),
                             E.FRBRalias(value="Untitled", name="title"),
-                            E.FRBRdate(date=today, name="Generation"),
+                            E.FRBRdate(date=frbr_uri.date, name="Generation"),
                             E.FRBRauthor(href=""),
                             E.FRBRcountry(value=frbr_uri.place),
                             E.FRBRnumber(value=frbr_uri.number),
@@ -355,6 +355,7 @@ class StructuredDocument(AkomaNtosoDocument):
             ident.FRBRWork.FRBRuri.set('value', uri.uri())
             ident.FRBRWork.FRBRthis.set('value', uri.work_uri())
             ident.FRBRWork.FRBRcountry.set('value', uri.place)
+            ident.FRBRWork.FRBRdate.set('date', uri.date)
 
             if uri.subtype:
                 self.ensure_element('FRBRsubtype', at=ident.FRBRWork, after=ident.FRBRWork.FRBRcountry).set('value', uri.subtype)

--- a/cobalt/xsd/akomantoso30-lenient.xsd
+++ b/cobalt/xsd/akomantoso30-lenient.xsd
@@ -10,6 +10,7 @@
 
      NOTE: this lenient schema has been modified as follows:
      - eId attributes do not need to be unique
+     - the 'date' attribute type also accepts dates that are only years
 -->
 <xsd:schema xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" elementFormDefault="qualified">
 	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="./xml.xsd"/>
@@ -628,7 +629,7 @@ The attribute date is used to give a normalized value for a date according to th
 		</xsd:annotation>
 		<xsd:attribute name="date" use="required">
 			<xsd:simpleType>
-				<xsd:union memberTypes="xsd:date xsd:dateTime"/>
+				<xsd:union memberTypes="xsd:date xsd:dateTime xsd:gYear"/>
 			</xsd:simpleType>
 		</xsd:attribute>
 	</xsd:attributeGroup>

--- a/tests/test_structured_document.py
+++ b/tests/test_structured_document.py
@@ -65,9 +65,15 @@ class StructuredDocumentTestCase(TestCase):
         assert_validates(a)
 
     def test_work_date(self):
+        """ Work date must be the FRBR date.
+        """
         a = Act()
-        a.work_date = '2012-01-02'
+        a.frbr_uri = '/akn/za/act/2012-01-02/5'
         assert_equal(datestring(a.work_date), '2012-01-02')
+        assert_is_instance(a.work_date, date)
+
+        a.frbr_uri = '/akn/za/act/2009/5'
+        assert_equal(datestring(a.work_date), '2009-01-01')
         assert_is_instance(a.work_date, date)
 
     def test_expression_date(self):

--- a/tests/test_structured_document.py
+++ b/tests/test_structured_document.py
@@ -15,6 +15,7 @@ class StructuredDocumentTestCase(TestCase):
         a = Act()
         a.expression_date = '2012-01-01'
         a.frbr_uri = '/zm/act/2007/01'
+        today = datestring(date.today())
 
         assert_equal(a.frbr_uri.work_uri(), '/zm/act/2007/01')
 
@@ -22,13 +23,16 @@ class StructuredDocumentTestCase(TestCase):
         assert_equal(a.meta.identification.FRBRWork.FRBRuri.get('value'), '/zm/act/2007/01')
         assert_equal(a.meta.identification.FRBRWork.FRBRcountry.get('value'), 'zm')
         assert_equal(a.meta.identification.FRBRWork.FRBRnumber.get('value'), '01')
+        assert_equal(a.meta.identification.FRBRWork.FRBRdate.get('date'), '2007')
 
         assert_equal(a.meta.identification.FRBRExpression.FRBRthis.get('value'), '/zm/act/2007/01/eng@2012-01-01/!main')
         assert_equal(a.meta.identification.FRBRExpression.FRBRuri.get('value'), '/zm/act/2007/01/eng@2012-01-01')
+        assert_equal(a.meta.identification.FRBRExpression.FRBRdate.get('date'), '2012-01-01')
 
         assert_equal(a.meta.identification.FRBRManifestation.FRBRthis.get('value'),
                      '/zm/act/2007/01/eng@2012-01-01/!main')
         assert_equal(a.meta.identification.FRBRManifestation.FRBRuri.get('value'), '/zm/act/2007/01/eng@2012-01-01')
+        assert_equal(a.meta.identification.FRBRManifestation.FRBRdate.get('date'), today)
 
         assert_validates(a)
 
@@ -399,7 +403,7 @@ class ActTestCase(TestCase):
           <FRBRthis value="/akn/za/act/1900/1/!main"/>
           <FRBRuri value="/akn/za/act/1900/1"/>
           <FRBRalias value="Untitled" name="title"/>
-          <FRBRdate date="TODAY" name="Generation"/>
+          <FRBRdate date="1900" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
           <FRBRnumber value="1"/>
@@ -454,7 +458,7 @@ class ActTestCase(TestCase):
           <FRBRthis value="/akn/za/act/1900/1/!main"/>
           <FRBRuri value="/akn/za/act/1900/1"/>
           <FRBRalias value="Untitled" name="title"/>
-          <FRBRdate date="TODAY" name="Generation"/>
+          <FRBRdate date="1900" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
           <FRBRnumber value="1"/>
@@ -522,7 +526,7 @@ class ActTestCase(TestCase):
           <FRBRthis value="/akn/za/act/1900/1/!main"/>
           <FRBRuri value="/akn/za/act/1900/1"/>
           <FRBRalias value="Untitled" name="title"/>
-          <FRBRdate date="TODAY" name="Generation"/>
+          <FRBRdate date="1900" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/>
           <FRBRnumber value="1"/>


### PR DESCRIPTION
We make the lenient schema allow dates that are only years.

This also makes the `work_date` property read-only, because that date must be set via the FRBR URI.

Fixes #41