### PR TITLE
Define a repr, and str tries to display the best version it can

### DIFF
--- a/cobalt/uri.py
+++ b/cobalt/uri.py
@@ -185,7 +185,14 @@ class FrbrUri(object):
         return uri
 
     def __str__(self):
+        if self.format:
+            return self.manifestation_uri()
+        if self.expression_date or self.expression_component:
+            return self.expression_uri()
         return self.work_uri()
+
+    def __repr__(self):
+        return f'<FrbrUri({self})>'
 
     @classmethod
     def parse(cls, s):


### PR DESCRIPTION
```python
>>> from cobalt import FrbrUri
>>> f = FrbrUri.parse('/akn/za/act/1992/1/eng')
>>> f
<FrbrUri(/akn/za/act/1992/1)>
>>> str(f)
'/akn/za/act/1992/1'
>>> f = FrbrUri.parse('/akn/za/act/1992/1/eng@2019-01-01')
>>> str(f)
'/akn/za/act/1992/1/eng@2019-01-01'
>>> repr(f)
'<FrbrUri(/akn/za/act/1992/1/eng@2019-01-01)>'
>>> f = FrbrUri.parse('/akn/za/act/1992/1/')
>>> f
<FrbrUri(/akn/za/act/1992/1)>
```