### PR TITLE
Explicitly set namespace on the maker

### DIFF
--- a/cobalt/akn.py
+++ b/cobalt/akn.py
@@ -41,7 +41,8 @@ objectify_parser.set_element_class_lookup(objectify.ObjectifyElementClassLookup(
 
 
 def get_maker(version=DEFAULT_VERSION):
-    return ElementMaker(nsmap={None: AKN_NAMESPACES[version]})
+    ns = AKN_NAMESPACES[version]
+    return ElementMaker(nsmap={None: ns}, namespace=ns)
 
 
 class AkomaNtosoDocument:


### PR DESCRIPTION
Otherwise, while serialised XML is correct, elements created by the
maker don't internally have the correct namespace.